### PR TITLE
Primary colors structure update

### DIFF
--- a/tokens.json
+++ b/tokens.json
@@ -75,6 +75,11 @@
       "primary": {
         "value": "$blue.500",
         "type": "color"
+      },
+      "primaryContrast": {
+        "value": "$base.white",
+        "type": "color",
+        "description": "Primary Contrast color used for text in primary buttons and active sidebar menu items"
       }
     },
     "focus": {
@@ -341,7 +346,7 @@
             "type": "color"
           },
           "active": {
-            "value": "$base.white",
+            "value": "$base.primaryContrast",
             "type": "color"
           }
         },
@@ -371,7 +376,7 @@
             "type": "color"
           },
           "active": {
-            "value": "$base.white",
+            "value": "$base.primaryContrast",
             "type": "color"
           }
         },
@@ -462,97 +467,6 @@
       }
     }
   },
-  "Sinch": {
-    "input": {
-      "border": {
-        "invalid": {
-          "value": "orange",
-          "type": "color"
-        }
-      }
-    },
-    "base": {
-      "primary": {
-        "value": "#00ff1f",
-        "type": "color"
-      }
-    },
-    "navigation": {
-      "subLevel": {
-        "background": {
-          "active": {
-            "value": "$base.primary",
-            "type": "color"
-          },
-          "hover": {
-            "value": "#51000e",
-            "type": "color"
-          },
-          "default": {
-            "value": "#51000e",
-            "type": "color"
-          }
-        },
-        "text": {
-          "active": {
-            "value": "#51000e",
-            "type": "color"
-          },
-          "hover": {
-            "value": "#ffffff",
-            "type": "color"
-          },
-          "default": {
-            "value": "$base.primary",
-            "type": "color"
-          }
-        }
-      },
-      "topLevel": {
-        "background": {
-          "active": {
-            "value": "$base.primary",
-            "type": "color"
-          },
-          "hover": {
-            "value": "#720814",
-            "type": "color"
-          },
-          "default": {
-            "value": "#720814",
-            "type": "color"
-          }
-        },
-        "text": {
-          "active": {
-            "value": "#51000e",
-            "type": "color"
-          },
-          "hover": {
-            "value": "#ffffff",
-            "type": "color"
-          },
-          "default": {
-            "value": "$base.primary",
-            "type": "color"
-          }
-        }
-      }
-    },
-    "focus": {
-      "navigation": {
-        "value": {
-          "x": "0",
-          "y": "0",
-          "blur": "0",
-          "spread": "3",
-          "color": "#e7cdd0",
-          "type": "innerShadow"
-        },
-        "type": "boxShadow"
-      }
-    }
-  },
   "SimpleTexting": {
     "base": {
       "primary": {
@@ -610,5 +524,31 @@
       "value": "8",
       "type": "borderRadius"
     }
-  }
+  },
+  "SinchSMB": {
+    "base": {
+      "primary": {
+        "value": "#ffc658",
+        "type": "color"
+      },
+      "primaryContrast": {
+        "value": "$text.primary",
+        "type": "color"
+      }
+    },
+    "focus": {
+      "navigation": {
+        "value": {
+          "x": "0",
+          "y": "0",
+          "blur": "0",
+          "spread": "3",
+          "color": "#e7cdd0",
+          "type": "innerShadow"
+        },
+        "type": "boxShadow"
+      }
+    }
+  },
+  "MessageMedia": {}
 }


### PR DESCRIPTION
- Primary Contrast color added (will be used for text in areas with Primary background)
- Now we only the active color will be applied for sidebar menu customization—all the secondary colors will stay the same.
- Base theme contains all the available tokens
- Exportable themes list now contains SimpleTexting, MessageMedia, and SinchSMB(future vision) themes